### PR TITLE
Don't crash out as soon as hitting an unsupported condition.

### DIFF
--- a/src/thd_engine_adaptive.cpp
+++ b/src/thd_engine_adaptive.cpp
@@ -357,18 +357,19 @@ int cthd_engine_adaptive::verify_condition(struct condition condition) {
 	if (condition.condition == Default)
 		return 0;
 
-	thd_log_fatal("Unsupported condition %d, exiting\n", condition.condition);
+	thd_log_error("Unsupported condition %d, exiting\n", condition.condition);
 	return THD_ERROR;
 }
 
 int cthd_engine_adaptive::verify_conditions() {
+	int result = 0;
 	for (int i = 0; i < (int)conditions.size(); i++) {
 		for (int j = 0; j < (int)conditions[i].size(); j++) {
 			if (verify_condition(conditions[i][j]))
-				return THD_ERROR;
+				result = THD_ERROR;
 		}
 	}
-	return 0;
+	return result;
 }
 
 int cthd_engine_adaptive::evaluate_condition(struct condition condition) {


### PR DESCRIPTION
This changes both the fatal into an error, and the loop to report _all_
unsupported conditions at once.

It should make it easier to gauge how much work is neded to support a
certain firmware.