### PR TITLE
Add missing build dependencies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -64,6 +64,8 @@ Building on Ubuntu
 	sudo apt-get install libdbus-1-dev
 	sudo apt-get install libdbus-glib-1-dev
 	sudo apt-get install libxml2-dev
+	sudo apt-get install libupower-glib-dev
+	sudo apt-get install liblzma-dev
 
 2
 Build


### PR DESCRIPTION
Document new build dependencies for Ubuntu / Debian in `README.txt`:

* `liblzma-dev`
* `libupower-glib-dev`