### PR TITLE
Add an explicit warning if a sensor is created without control_path.

### DIFF
--- a/src/thd_sensor.cpp
+++ b/src/thd_sensor.cpp
@@ -30,6 +30,8 @@ cthd_sensor::cthd_sensor(int _index, std::string control_path,
 		index(_index), type(_type), sensor_sysfs(control_path.c_str()), sensor_active(
 				false), type_str(_type_str), async_capable(false), virtual_sensor(
 				false), thresholds(0), scale(1) {
+	if (control_path.empty())
+		thd_log_warn("Missing control_path for sensor id %d (type: %s)\n", index, type_str.c_str());
 
 }
 


### PR DESCRIPTION
Without this, the output will be an ominous warning:

    [WARN]sensor id 13 : No temp sysfs for reading raw temp

The extra space after `13` is meant to separate the index from the path,
but no path is supplied at all.

Changing this to warn at creation makes it easier to figure out what's
going on:

    [WARN]Missing control_path for sensor id 13 (type: amdgpu-temperature)
    [WARN]sensor id 13 : No temp sysfs for reading raw temp

And so it scares less, as I don't have an AMD GPU at all.